### PR TITLE
MAINT: rename project name into ansys-magnet-segmentation-toolkit

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -16,7 +16,7 @@ on:
 env:
   MAIN_PYTHON_VERSION: '3.10'
   DOCUMENTATION_CNAME: 'aedt.magnet.segmentation.toolkit.docs.pyansys.com'
-  PACKAGE_NAME: 'ansys-aedt-toolkits-magnet-segmentation'
+  PACKAGE_NAME: 'ansys-magnet-segmentation-toolkit'
   ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
 
 concurrency:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -33,7 +33,7 @@ html:
 pdf:
 	@$(SPHINXBUILD) -M latex "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	cd $(BUILDDIR)/latex && latexmk -r latexmkrc -pdf *.tex -interaction=nonstopmode || true
-	(test -f $(BUILDDIR)/latex/ansys-aedt-toolkits-magnet-segmentation.pdf && echo pdf exists) || exit 1
+	(test -f $(BUILDDIR)/latex/ansys-magnet-segmentation-toolkit.pdf && echo pdf exists) || exit 1
 
 # build docs like the CI build
 cibuild:

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -43,7 +43,7 @@ goto end
 cd "%BUILDDIR%\latex"
 for %%f in (*.tex) do (
 xelatex "%%f" --interaction=nonstopmode)
-if NOT EXIST ansys-aedt-toolkits-magnet-segmentation.pdf (
+if NOT EXIST ansys-magnet-segmentation-toolkit.pdf (
 	Echo "no pdf generated!"
 	exit /b 1)
 Echo "pdf generated!"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -67,7 +67,7 @@ def setup(app):
 
 
 # Project information
-project = "ansys-aedt-toolkits-magnet-segmentation"
+project = "ansys-magnet-segmentation-toolkit"
 copyright = f"(c) {datetime.now().year} ANSYS, Inc. All rights reserved"
 author = "ANSYS, Inc."
 release = version = __version__
@@ -82,7 +82,7 @@ os.environ["PYAEDT_NON_GRAPHICAL"] = "1"
 # Select desired logo, theme, and declare the html title
 html_logo = pyansys_logo_black
 html_theme = "ansys_sphinx_theme"
-html_short_title = html_title = "ansys-aedt-toolkits-magnet-segmentation"
+html_short_title = html_title = "ansys-magnet-segmentation-toolkit"
 
 # specify the location of your GitHub repo
 html_context = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
-name = "ansys-aedt-toolkits-magnet-segmentation"
+name = "ansys-magnet-segmentation-toolkit"
 dynamic = ["version"]
 description = "Toolkit used for automating the segmentation and skew of interior permanent magnet (IPM) and surface permanent magnet (SPM) motors using Ansys Electronics Desktop (AEDT)"
 readme = "README.rst"


### PR DESCRIPTION
Previous name used `pyaedt` toolkits convention but this toolkit next goal is to be used with `pymotorcad` (making it working without `pyaedt`). 