### PR TITLE
DOCS: Fix build html

### DIFF
--- a/doc/source/Toolkit/api.rst
+++ b/doc/source/Toolkit/api.rst
@@ -17,7 +17,7 @@ automating the segmentation and skew of a 3D motor.
 .. autosummary::
    :toctree: _autosummary
 
-   Toolkit
+   ToolkitBackend
 
 This code shows how to use the ``ToolkitBackend`` class:
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -69,8 +69,7 @@ def check_example_error(app, pagename, context):
             logger.error(f"An error was detected in file {pagename}")
             app.builder.config.html_context["build_error"] = True
 
-
-def check_build_finished_without_error(app):
+def check_build_finished_without_error(app, exception):
     """Check that no error is detected along the documentation build process."""
     if app.builder.config.html_context.get("build_error", False):
         raise Exception("Build failed due to an error in html-page-context")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -69,6 +69,7 @@ def check_example_error(app, pagename, context):
             logger.error(f"An error was detected in file {pagename}")
             app.builder.config.html_context["build_error"] = True
 
+
 def check_build_finished_without_error(app, exception):
     """Check that no error is detected along the documentation build process."""
     if app.builder.config.html_context.get("build_error", False):


### PR DESCRIPTION
Fix two issues with the documentation:
- the wrong class name was used (missed during the transition to the toolkit-common)
- the sphinx event hook used to handle errors and fail the CI was wrongly defined

@gmalinve This should let us create a new release !