### PR TITLE
CI: Use Trusted Publisher to release package

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -199,13 +199,17 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: build-library
     runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: "Release to the public PyPI repository"
         uses: ansys/actions/release-pypi-public@v6
         with:
           library-name: ${{ env.PACKAGE_NAME }}
-          twine-username: "__token__"
-          twine-token: ${{ secrets.PYPI_TOKEN }}
+          use-trusted-publisher: true
 
       - name: "Release to GitHub"
         uses: ansys/actions/release-github@v6


### PR DESCRIPTION
We are planning to transition from using secret tokens to utilizing Trusted Publisher for our public package distribution.

This change will enhance:

- our security as secrets can be exposed inadvertently through leaks;
- our workflows as managing and rotating secrets requires additional effort (and can be error-prone).

Once this is merged, I'll contact the right person to proceed with updating our `pypi` settings.