### PR TITLE
CHORE: Cover only magnet segmentation backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ src_paths = ["doc", "src", "tests"]
 source = ["ansys.aedt.toolkits.magnet_segmentation"]
 omit = [
     # Omit UI testing
-    "src/ansys/aedt/toolkits/magnet_segmentation/ui/*,
+    "src/ansys/aedt/toolkits/magnet_segmentation/ui/*",
 ]
 relative_files = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,11 @@ default_section = "THIRDPARTY"
 src_paths = ["doc", "src", "tests"]
 
 [tool.coverage.run]
-source = ["ansys.aedt"]
+source = ["ansys.aedt.toolkits.magnet_segmentation"]
+omit = [
+    # Omit UI testing
+    "src/ansys/aedt/toolkits/magnet_segmentation/ui/*,
+]
 relative_files = true
 
 [tool.coverage.report]


### PR DESCRIPTION
There seem to be an issue with the coverage configuration.

Previously, when PyAEDT was still installed in pyaedt it was not an issue but now that we are installing it as ansys.aedt.core, the coverage got mixed. This changes should ensure that the project is covering the correct files.