### PR TITLE
REFACTOR: Specify timeout value in every calls to ``requests.post()`` and ``requests.get()``

### DIFF
--- a/doc/changelog.d/291.miscellaneous.md
+++ b/doc/changelog.d/291.miscellaneous.md
@@ -1,0 +1,1 @@
+Specify timeout value in every calls to \`\`requests.post()\`\` and \`\`requests.get()\`\`

--- a/src/ansys/aedt/toolkits/magnet_segmentation/ui/actions.py
+++ b/src/ansys/aedt/toolkits/magnet_segmentation/ui/actions.py
@@ -123,7 +123,7 @@ class Frontend(FrontendGeneric):
 
         self.set_properties(be_properties)
         try:
-            segmentation_response = requests.post(self.url + "/apply_segmentation")
+            segmentation_response = requests.post(self.url + "/apply_segmentation", timeout=60)
             if segmentation_response.ok:
                 # self.find_design_names()
                 # self.skew.setEnabled(True)
@@ -163,7 +163,7 @@ class Frontend(FrontendGeneric):
 
         if be_properties["skew_angle"]:
             try:
-                response = requests.post(self.url + "/apply_skew")
+                response = requests.post(self.url + "/apply_skew", timeout=60)
                 if response.ok:
                     msg = "Apply skew call successful."
                     logger.info(msg)
@@ -195,7 +195,7 @@ class Frontend(FrontendGeneric):
         self.set_properties(be_properties)
 
         try:
-            response = requests.post(self.url + "/validate_analyze")
+            response = requests.post(self.url + "/validate_analyze", timeout=60)
             if response.ok:
                 msg = "Validate and analyze call successful"
                 logger.info(msg)
@@ -227,7 +227,7 @@ class Frontend(FrontendGeneric):
         self.set_properties(be_properties)
 
         try:
-            response = requests.get(self.url + "/magnet_loss")
+            response = requests.get(self.url + "/magnet_loss", timeout=60)
             if response.ok:
                 msg = "Magnet loss call successful."
                 logger.info(msg)
@@ -241,7 +241,7 @@ class Frontend(FrontendGeneric):
 
     def get_materials_action(self):
         try:
-            response = requests.get(self.url + "/project_materials")
+            response = requests.get(self.url + "/project_materials", timeout=60)
             if response.ok:
                 msg = "Load materials call successful."
                 logger.info(msg)
@@ -256,7 +256,7 @@ class Frontend(FrontendGeneric):
 
     def get_design_setups(self):
         try:
-            response = requests.get(self.url + "/design_setups")
+            response = requests.get(self.url + "/design_setups", timeout=60)
             if response.ok:
                 msg = "Get design setups call successful."
                 logger.info(msg)


### PR DESCRIPTION
This PR introduces the definition of a timeout value in every calls to ``requests.post()`` and ``requests.get()``.

Using these methods without a timeout can lead to hanging requests, which can be exploited by attackers to cause denial of service (DoS) conditions. This topic is further discussed [here](https://bandit.readthedocs.io/en/latest/plugins/b113_request_without_timeout.html) and exemplified in the pyansys dev-guide [here](https://dev.docs.pyansys.com/how-to/vulnerabilities.html#addressing-common-vulnerabilities-in-python-libraries-and-applications).

To the reviewers: The 60 seconds currently specified for the timeouts are arbitrary and can be updated if other values would make more sense!