### PR TITLE
CI: Fixes for ``smoke-tests`` and ``build-application-windows`` jobs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -124,8 +124,10 @@ jobs:
       - name: Debug build directory
         run: Get-ChildItem -Path build -Recurse | ForEach-Object { $_.FullName }
 
-      - name: Print NSIS version
-        run: makensis -VERSION
+      - name: Check NSIS version
+        shell: pwsh
+        run: |
+          & "C:\Program Files (x86)\NSIS\makensis.exe" /VERSION
 
       - name: Run NSIS
         shell: pwsh
@@ -136,15 +138,17 @@ jobs:
           if (!(Test-Path -Path "setup.nsi")) {
             Write-Error "setup.nsi not found"
           }
-          makensis setup.nsi
+          & "C:\Program Files (x86)\NSIS\makensis.exe" setup.nsi
 
       - name: List output
-        run: ls -R dist
+        shell: pwsh
+        run: Get-ChildItem -Recurse dist
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: Magnet-Segmentation-Toolkit-Installer-windows
           path: dist/*.exe
+          if-no-files-found: error
 
   build-application-linux-debian:
     strategy:
@@ -281,7 +285,7 @@ jobs:
           library-name: ${{ env.LIBRARY_NAME }}
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
-          whitelist-license-check: 'jeepney'
+          whitelist-license-check: 'jeepney fpdf2 PySide6 PySide6_Addons PySide6_Essentials shiboken6'
 
   tests_windows:
     name: "Windows Tests AEDT"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+Copyright (c) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/doc/changelog.d/294.maintenance.md
+++ b/doc/changelog.d/294.maintenance.md
@@ -1,0 +1,1 @@
+Fixes for \`\`smoke-tests\`\` and \`\`build-application-windows\`\` jobs

--- a/installer/extract_version.py
+++ b/installer/extract_version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/installer/hooks/hook-ansys.aedt.core.py
+++ b/installer/hooks/hook-ansys.aedt.core.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/installer/hooks/hook-ansys.aedt.toolkits.common.py
+++ b/installer/hooks/hook-ansys.aedt.toolkits.common.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/installer/hooks/hook-ansys.aedt.toolkits.magnet_segmentation.py
+++ b/installer/hooks/hook-ansys.aedt.toolkits.magnet_segmentation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/installer/hooks/hook-ansys.tools.visualization_interface.py
+++ b/installer/hooks/hook-ansys.tools.visualization_interface.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/magnet_segmentation/__init__.py
+++ b/src/ansys/aedt/toolkits/magnet_segmentation/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/magnet_segmentation/backend/__init__.py
+++ b/src/ansys/aedt/toolkits/magnet_segmentation/backend/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/magnet_segmentation/backend/api.py
+++ b/src/ansys/aedt/toolkits/magnet_segmentation/backend/api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/magnet_segmentation/backend/models.py
+++ b/src/ansys/aedt/toolkits/magnet_segmentation/backend/models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/magnet_segmentation/backend/run_backend.py
+++ b/src/ansys/aedt/toolkits/magnet_segmentation/backend/run_backend.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/magnet_segmentation/backend/workflows/__init__.py
+++ b/src/ansys/aedt/toolkits/magnet_segmentation/backend/workflows/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/magnet_segmentation/backend/workflows/aedt.py
+++ b/src/ansys/aedt/toolkits/magnet_segmentation/backend/workflows/aedt.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/magnet_segmentation/run_toolkit.py
+++ b/src/ansys/aedt/toolkits/magnet_segmentation/run_toolkit.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/magnet_segmentation/ui/__init__.py
+++ b/src/ansys/aedt/toolkits/magnet_segmentation/ui/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/magnet_segmentation/ui/actions.py
+++ b/src/ansys/aedt/toolkits/magnet_segmentation/ui/actions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/magnet_segmentation/ui/models.py
+++ b/src/ansys/aedt/toolkits/magnet_segmentation/ui/models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/magnet_segmentation/ui/run_frontend.py
+++ b/src/ansys/aedt/toolkits/magnet_segmentation/ui/run_frontend.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/magnet_segmentation/ui/splash.py
+++ b/src/ansys/aedt/toolkits/magnet_segmentation/ui/splash.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/tests/tests_aedt/__init__.py
+++ b/tests/tests_aedt/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/tests/tests_aedt/conftest.py
+++ b/tests/tests_aedt/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/tests/tests_aedt/test_motor_workflow.py
+++ b/tests/tests_aedt/test_motor_workflow.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
This PR is providing fixes for two jobs that are currently failing on the CI:
* The ``smoke-tests`` job is failing when executing the ``ansys/actions/build-wheelhouse`` action due to invalid licenses found among the dependencies of the project as described in #292. The fix here consists in whitelisting the affected packages, following the approach applied in https://github.com/ansys/pyaedt-toolkits-common/pull/351,
* The ``build-application-windows`` job is failing after the installation of ``NSIS``. While the install is successful, the simple check that consists in printing the tool's version and the following step of the job in which the tool is actually run are both failing. This is resolved by specifying the entire path to the installed tool in both steps. Furthermore, a few minor adjustments are made to two other steps of the ``build-application-windows`` job based on the current implementation of that same job in the ``ansys-aedt-toolkits-radar-explorer``.

Close #292.
Many license headers are also updated (extending copyright to 2026) on top of the changes described above.